### PR TITLE
no longer override Apache's default 401 page text

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+
+ . Drop override of Apache's misleading default 401 page text, and
+   recommend to use "AuthzSendForbiddenOnFailure On" instead
+   (available since Apache 2.3.11).
+
 2.0.4 - 2017-05-24 mgk25
 
  . Fix handling of directive "ErrorDocument 401 ..." on Apache 2.4.13 or later

--- a/README.Config
+++ b/README.Config
@@ -142,20 +142,21 @@ a particular directory to anybody with a Ucam-WebAuth login is, e.g.
   AACookieKey "some random string"
   <Directory "path to protected directory">
     AuthType Ucam-WebAuth
+    AuthzSendForbiddenOnFailure On
     Require valid-user
   </Directory>
 
 An alternative simple configuration will allow access to the resources
 to users with a Ucam-WebAuth login or to client computers with
-hostnames ending .cam.ac.uk, but not otherwise:
+hostnames ending .cam.ac.uk or with a CUDN IPv6 address, but not otherwise:
 
   AACookieKey "some random string"
   <Directory "path to protected directory">
-    Order allow,deny
-    Allow from .cam.ac.uk
+    Require ip 2001:630:210::/44
+    Require host .cam.ac.uk
     AuthType Ucam-WebAuth
+    AuthzSendForbiddenOnFailure On
     Require valid-user
-    Satisfy any
   </Directory>
 
 In these examples the resources to be protected are selected by a
@@ -164,8 +165,8 @@ directives can also be protected in the same way. 'AuthType' must be
 set to 'Ucam-WebAuth'. A 'Require' directive must appear before
 authentication will take place.
 
-See standard Apache documentation for more details of the 'Order',
-'Allow', 'Require', and 'Satisfy' directives.
+See standard Apache 2.4 documentation for more details of the
+'Require' directive.
 
 The AACookieKey directive is required, though it can appear either
 outside the <Directory> block, in which case it provides a default for
@@ -790,15 +791,23 @@ closely match the look and feel of the site.
 
 Error pages for 'Bad Request', 'General server error', 'Forbidden',
 and 'Authorization Required' can be established using the standard
-ErrorDocument directive for status codes 400, 500, 403, and 401. A
-modified 401 page will be provided if a custom one is not defined
-since the Apache default is misleading. The default Apache 400 and 500
-pages will be used (and may well be satisfactory) if a custom page is
-not defined for these codes. Note that under Apache version 1 (though
-not version 2), the default 400 page includes the text of messages
-recently sent to the error log. While this does not revel any
-sensitive information in the case of mod_ucam_webauth, it does make
-the pages look somewhat 'messy'.
+ErrorDocument directive for status codes 400, 500, 403, and 401.
+
+By default, in case authorization has failed after successful
+authentication, Apache shows a 401 page that misleadingly mentions bad
+passwords. Therefore, for Apache 2.3.11 or newer, we recommend to set
+
+  AuthzSendForbiddenOnFailure On
+
+whenever "AuthType Ucam-Webauth" is active, which results in a more
+appropriate "Forbidden" message and 403 status.
+
+The default Apache 400 and 500 pages will be used (and may well be
+satisfactory) if a custom page is not defined for these codes. Note
+that under Apache version 1 (though not version 2), the default 400
+page includes the text of messages recently sent to the error log.
+While this does not reveal any sensitive information in the case of
+mod_ucam_webauth, it does make the pages look somewhat 'messy'.
 
 Custom error pages for 'User declined to authenticate', 'Interaction
 with user would be required', 'User lacking a required ptag', and


### PR DESCRIPTION
Apache lacks a proper core API for modules to override the default
text, so this was a fragile hack. Instead, as suggested in issue #16, advise users to use
```
AuthzSendForbiddenOnFailure On
```
such that authorization failure is reported via the more appropriate
403 status code and page. This will make future breakage such as issue #11
less likely whenever Apache next changes their ErrorDocument data structures.

Note that [AuthzSendForbiddenOnFailure](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#authzsendforbiddenonfailure) was only introduced in Apache 2.3.11,
so Apache 2.2 users may prefer not to apply this patch.