### PR TITLE
Fix 'hmtl' closing tag typo

### DIFF
--- a/mod_ucam_webauth.c
+++ b/mod_ucam_webauth.c
@@ -3156,7 +3156,7 @@ webauth_handler_logout(request_rec *r)
        "you should first log-out of all other personalized sites that you "
        "have accessed and then <a href=\"", c->logout_service,
        "\">logout from the central authentication service</a>.",
-       sig, "</body></hmtl>", NULL);
+       sig, "</body></html>", NULL);
   }
   ap_rputs(response,r);
   return OK;


### PR DESCRIPTION
The final closing tag in the HTML markup for the built-in logout message was incorrect, being `</hmtl>` instead of `</html>`.