### PR TITLE
Add AACanonicaliseName setting to control redirection to the canonical ServerName

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+2.0.6 - 2019-09-06 mas90
+
+  . Add new configuration directive AACanonicaliseName to configure whether
+    to always redirect using ServerName (default) or to honour Apache's
+    UseCanonicalName configuration (useful for virtual hosts with configured
+    ServerAliases)
+
 2.0.5 - 2017-05-26 mgk25
 
   . delete obsolete Apache 1.3 code and macros (GitHub #18)

--- a/README.Config
+++ b/README.Config
@@ -770,6 +770,24 @@ AAForceAuthType
   'AAForceAuthType Basic' could allow authentication systems intended
   for use with HTTP Basic Auth to work under Ucam-WebAuth.
 
+AACanonicaliseName
+
+  Syntax:   AACanonicaliseName Off|On
+  Default:  AACanonicaliseName On
+  Context:  all
+  Override: AuthConfig
+  Module:   mod_ucam_webauth
+
+  If set to On (default), the user will be redirected to the virtual
+  host's canonical hostname (ServerName), and that name will be used
+  whenever a redirection URL is constructed.  This will ensure that
+  cookies are always set and retrieved using the primary domain.
+
+  If set to Off, the user will not be explicitly redirected by this
+  module, and the setting of Apache's UseCanonicalName configuration
+  directive will be honoured when constructing redirect URLs; see
+  https://httpd.apache.org/docs/current/mod/core.html#usecanonicalname
+
 Versions of the module prior to 1.0.0 supported the AALogLevel
 directive. Support for this has been withdrawn - at present any use of
 this directive causes a warning to be logged; in due course use of

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+libapache2-mod-ucam-webauth (2.0.6apache24) unstable; urgency=medium
+
+  * Add new configuration directive AACanonicaliseName to configure whether
+    to always redirect using ServerName (default) or to honour Apache's
+    UseCanonicalName configuration (useful for virtual hosts with configured
+    ServerAliases)
+
+ -- Malcolm Scott <mas90@cam.ac.uk>  Sat, 06 Jul 2019 12:37:24 +0100
+
 libapache2-mod-ucam-webauth (2.0.5apache24) unstable; urgency=low
 
   * Modify package to include recent improvements

--- a/mod_ucam_webauth.conf.skel
+++ b/mod_ucam_webauth.conf.skel
@@ -47,3 +47,6 @@ LoadModule ucam_webauth_module @@LIBEXECDIR@@/mod_ucam_webauth.so
 # AAAlwaysDecode  Off
 
 # AAAlwaysDecode  Off
+
+# AACanonicaliseName On
+


### PR DESCRIPTION
By default, mod_ucam_webauth redirects clients to the canonical server hostname so that cookies end up set on that domain.  That is not desirable behaviour on some environments, e.g. the SRCF where the ServerName (as set by the system administrator) might not match the user's preferred domain, and might cause the cookie to go missing if the website forces redirection to a non-canonical ServerAlias.

So, I've added a new configuration directive (AACanonicaliseName) to allow this behaviour to be overridden (either globally, in a <Directory> block or in .htaccess).  If "AACanonicaliseName off" is configured, mod_ucam_webauth will not explicitly redirect to the canonical name, and will let ap_construct_url determine what name to use when a full self-referential URL is needed (according to Apache's UseCanonicalName directive).  I have not changed the default behaviour.

The SRCF has been running with an early version of this patch for many years without issue.