### PR TITLE
Stop AAAuthService overwriting logout service URL

### DIFF
--- a/mod_ucam_webauth.c
+++ b/mod_ucam_webauth.c
@@ -1608,7 +1608,7 @@ apply_config_defaults(request_rec *r,
 
   n->auth_service = c->auth_service != NULL ? c->auth_service :
       apr_pstrdup(r->pool,DEFAULT_auth_service);
-  n->logout_service = c->logout_service != NULL ? c->auth_service :
+  n->logout_service = c->logout_service != NULL ? c->logout_service :
       apr_pstrdup(r->pool, DEFAULT_logout_service);
   n->description = c->description != NULL ? c->description :
       DEFAULT_description;


### PR DESCRIPTION
When merging default configuration settings in apply_config_defaults(), the value that should be set by 'AALogoutService' (specifying a URL to which the user can be directed to log out of the central authentication service) will be clobbered if a custom 'AAAuthService' has also been
specified in configuration.  This is due to a typo.

The end result is that the AALogoutService directive is useless (even the default value will be blown away) if AAAuthService is specified.

This bug has probably never been discovered to date, because (almost) nobody uses a service that isn't production Raven, whose auth service and logout URLs are hard-coded as defaults.